### PR TITLE
Rework docker build and npm build logic

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,22 @@
-FROM node:14
-WORKDIR /app
-COPY . /app
+FROM node:14.16.0-alpine3.13 as build
+
+COPY . /build
+
+WORKDIR /build
+
 RUN npm run auto-install
+
+#
+
+FROM node:14.16.0-alpine3.13
+
+COPY --from=build /build/client/ /app/client
+COPY --from=build /build/server/ /app/server
+COPY package.json package-lock.json /app/
+
+COPY server/config.example.ts /app/server/config.ts
+
+WORKDIR /app
+
 EXPOSE 3030
 CMD ["npm", "start"]

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "scripts": {
     "start:client": "npm run build --prefix client",
     "start:server": "npm start --prefix server",
-    "start": "npm run translation:generate &&  npm run start:client && npm run start:server",
+    "start": "npm run start:server",
     "dev": "concurrently \"npm start --prefix server\" \"npm start --prefix client\"",
-    "auto-install": "node ./scripts/install.js",
+    "auto-install": "node ./scripts/install.js && npm run translation:generate && npm run start:client",
     "update": "node ./scripts/auto-update.js",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",


### PR DESCRIPTION
- Build on node alpine container instead. Final build size is 541MB rather than 1,4G
- Use multi-stage build logic, so we don't have to copy everything to the final container, which also saves size.
- As server config takes variables from ENV file, just copy it to the final container
- I didin't see a point why npm build needed to be run every time container starts, so I moved it to auto-install phase.

This needs some additional testing - maybe some files are still missing from final container.
